### PR TITLE
Add a `-d` to define a delay between strokes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ To press/release modifiers, `-M`/`-m` can be used respectively.
 wtype -M ctrl c -m ctrl
 ```
 
+To alter delay between keystrokes, `-d`.
+
+```
+# delay of 0 when typing "foo", 120ms on "bar"
+wtype foo -d 120 bar
+
+# also applied on stdin
+echo everything | wtype -d 12 -
+```
 
 To press/release a named key (as given by [xkb_keysym_get_name](https://xkbcommon.org/doc/current/group__keysyms.html)),
 `-P`/`-p` can be used.
@@ -33,6 +42,7 @@ To press/release a named key (as given by [xkb_keysym_get_name](https://xkbcommo
 # Press and release the Left key
 wtype -P left -p left
 ```
+
 Note that when wtype terminates, all the pressed keys/modifiers get released, as the compositor destroys the associated
 virtual keyboard object. To help performing a more complicated sequence of key presses, `-s` can be used to insert delays into the stream of key events.
 

--- a/man/wtype.1
+++ b/man/wtype.1
@@ -45,6 +45,11 @@ Release key KEY.
 Type (press and release) key KEY.
 
 .TP
+.BR \-d\ \fITIME\fR
+Sleep for TIME milliseconds between keystrokes when typing texts.
+Can be used multiple times, default 0.
+.TP
+
 .BR \-s\ \fITIME\fR
 Sleep for TIME milliseconds before interpreting the following options. This
 can be used to perform more complicated modifier sequences.


### PR DESCRIPTION
It's a change that I needed, but I don't use it anymore.

Maybe others can make use of it.