### PR TITLE
Drop Unicode keysym workaround

### DIFF
--- a/main.c
+++ b/main.c
@@ -431,11 +431,6 @@ static void print_keysym_name(xkb_keysym_t keysym, FILE *f)
 		return;
 	}
 
-	if (sym_name[0] == '0' && sym_name[1] == 'x') {
-		// Unicode, we need special handling for these for whatever reason
-		snprintf(sym_name, sizeof(sym_name), "U%04x", keysym);
-	}
-
 	fprintf(f, "%s", sym_name);
 }
 


### PR DESCRIPTION
I tried a lot of Unicode characters (e.g. "🐸") and it doesn't seem
like libxkbcommon ever returns something beginning with "0x". It
always returns the "U" string we expect.

Additionally, the workaround is wrong: "U" keysyms need a Unicode
code-point value, but we were using the keysym raw value instead.
These are not equal (try for yourself by removing the "if" condition).